### PR TITLE
fix: Ensure script compatibility with GNOME 48 and 49

### DIFF
--- a/nautilus-backspace.py
+++ b/nautilus-backspace.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import os, gi
-gi.require_version('Nautilus', '4.1')
 gi.require_version('Gtk', '4.0')
 from gi.repository import GObject, Nautilus, Gtk, Gio, GLib
 
@@ -9,7 +8,7 @@ class BackspaceBack(GObject.GObject, Nautilus.MenuProvider):
     def __init__(self):
         super().__init__()
         pass
-    
+
     def get_file_items(self, *args):
         app = Gtk.Application.get_default()
         app.set_accels_for_action("slot.back", ["BackSpace"])

--- a/nautilus-backspace.py
+++ b/nautilus-backspace.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python
 
-import os, gi
+import gi
 gi.require_version('Gtk', '4.0')
-from gi.repository import GObject, Nautilus, Gtk, Gio, GLib
+from gi.repository import GObject, Nautilus, Gtk
+
 
 class BackspaceBack(GObject.GObject, Nautilus.MenuProvider):
     def __init__(self):
         super().__init__()
-        pass
 
     def get_file_items(self, *args):
         app = Gtk.Application.get_default()
-        app.set_accels_for_action("slot.back", ["BackSpace"])
+        if not app.get_actions_for_accel("BackSpace"):
+            app.set_accels_for_action("slot.back", ["BackSpace"])
         return None
-


### PR DESCRIPTION
**Title:**
Ensure script works with GNOME 48 and 49

**Description:**
This PR updates the script to maintain compatibility across GNOME versions 48 and 49.

* Adjusted API usage to handle differences between versions.
* Verified that the script works as expected on both GNOME 48 and 49 environments.

This change ensures that users on either version can run the script without errors.